### PR TITLE
settings: サーバー起動時に自動で gamerule を設定するようにした

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,9 @@ services:
       OPS_FILE: /extra/ops.json
       # plugins
       SYNC_SKIP_NEWER_IN_DESTINATION: false
+      # rcon cmd
+    RCON_CMDS_STARTUP: |-
+      gamerule playersSleepingPercentage 50
     stdin_open: true
     ports:
       - 25565:25565


### PR DESCRIPTION
サーバー起動時に自動で gamerule を設定するコマンドを実行し、夜をスキップするためのベッドに寝ている人数の割合を変更するようにした。

- docker compose 設定: https://docker-minecraft-server.readthedocs.io/en/latest/configuration/auto-rcon-commands/#auto-execute-rcon-commands
- MC参考記事: https://minecraft.mixjuice.info/2020/12/17/gamerule-players-sleeping-percentage/